### PR TITLE
(DO NOT MERGE) Prototype TypeScript/ES6 Exercises Setup Using Unit Tests

### DIFF
--- a/exercises/es-ts-new/README.md
+++ b/exercises/es-ts-new/README.md
@@ -2,11 +2,16 @@
 
 1. Run `npm install` to install all the dependencies.
 
+# Compiling
+
+1. Run `npm run -s compile` to attempt to compile `exercise.ts`
+    * If compilation is successful, you will see a `Compilation was successful!` message.
+
 # Running
 
-1. Run `npm start` to run `exercise.ts`
+1. Run `npm -s start` to run `exercise.ts`
 
 # Testing 
 
-1. Run `npm test` to run run tests files marked with `.spec.ts` postfix.
-2. Run `npm run test:json` to run tests but with output in JSON format (for CI use).
+1. Run `npm -s test` to run run tests files marked with `.spec.ts` postfix.
+2. Run `npm run -s test:json` to run tests but with output in JSON format (for CI use).

--- a/exercises/es-ts-new/README.md
+++ b/exercises/es-ts-new/README.md
@@ -1,0 +1,12 @@
+# Setup
+
+1. Run `npm install` to install all the dependencies.
+
+# Running
+
+1. Run `npm start` to run `exercise.ts`
+
+# Testing 
+
+1. Run `npm test` to run run tests files marked with `.spec.ts` postfix.
+2. Run `npm run test:json` to run tests but with output in JSON format (for CI use).

--- a/exercises/es-ts-new/exercise.spec.ts
+++ b/exercises/es-ts-new/exercise.spec.ts
@@ -19,6 +19,14 @@ describe('TypeScript Classes', () => {
     expect(sonic.getWeight()).to.equal(10);
   });
 
+  it('should get 10 as the weight for hedge', () => {
+    expect(hedge.weight).to.equal(10);
+  })
+
+  it('should get 100 rings for sonic', () => {
+    expect(sonic.getNumberOfRings()).to.equal(100);
+  });
+
   it('should get blue as the colour for sonic', () => {
     expect(sonic.getColor()).to.equal('blue');
   });
@@ -36,5 +44,35 @@ describe('TypeScript Classes', () => {
     expect(sonic.getItems()).to.deep.equal(['speed shoes', 'fire shield']);
     expect(sonic.addItem('invincibility')).to.be.undefined;
     expect(sonic.getItems()).to.deep.equal(['speed shoes', 'fire shield', 'invincibility']);
-  })
+  });
+
+  it('add a new sidekick info to sonic\'s personal info object', () => {
+    expect(sonic.getPersonalInfo()).to.deep.equal({
+      age: 26,
+      faveConsole: 'Genesis'
+    });
+    expect(sonic.addNewPersonalInfo('sidekick', 'Tails')).to.be.undefined;
+    expect(sonic.getPersonalInfo()).to.deep.equal({
+      sidekick: 'Tails',
+      age: 26,
+      faveConsole: 'Genesis'
+    });
+  });
+
+  it('update color, weight and number of rings for Sonic at once', () => {
+    expect(sonic.getColor()).to.equal('red');
+    expect(sonic.getWeight()).to.equal(10);
+    expect(sonic.getNumberOfRings()).to.equal(100);
+
+    // update color, weight, rings at once using an object 
+    expect(sonic.setColorWeightRings({ 
+      color: 'blue',
+      weight: 15,
+      numberOfRings: 110
+    })).to.be.undefined;
+
+    expect(sonic.getColor()).to.equal('blue');
+    expect(sonic.getWeight()).to.equal(15);
+    expect(sonic.getNumberOfRings()).to.equal(110);
+  });
 })

--- a/exercises/es-ts-new/exercise.spec.ts
+++ b/exercises/es-ts-new/exercise.spec.ts
@@ -31,4 +31,10 @@ describe('TypeScript Classes', () => {
   it('should have sonic say its name', () => {
     expect(sonic.sayHi()).to.equal('Hi, my name is Sonic');
   });
+
+  it('add a new item "invincibility" at the end of the owned items list', () => {
+    expect(sonic.getItems()).to.deep.equal(['speed shoes', 'fire shield']);
+    expect(sonic.addItem('invincibility')).to.be.undefined;
+    expect(sonic.getItems()).to.deep.equal(['speed shoes', 'fire shield', 'invincibility']);
+  })
 })

--- a/exercises/es-ts-new/exercise.spec.ts
+++ b/exercises/es-ts-new/exercise.spec.ts
@@ -3,21 +3,32 @@ import { Hedgehog, Sonic } from './exercise';
 import { expect } from 'chai';
 
 describe('TypeScript Classes', () => {
+  let hedge: Hedgehog;
   let sonic: Sonic;
 
   before(() => {
+    hedge = new Hedgehog('brown', 10);
     sonic = new Sonic('blue', 10, 100);
   });
 
-  it('should get 100 rings', () => {
+  it('should get 100 rings for sonic', () => {
     expect(sonic.getNumberOfRings()).to.equal(100);
   });
 
-  it('should get 10 as the weight', () => {
+  it('should get 10 as the weight for sonic', () => {
     expect(sonic.getWeight()).to.equal(10);
   });
 
-  it('should get blue as the colour', () => {
+  it('should get blue as the colour for sonic', () => {
     expect(sonic.getColor()).to.equal('blue');
-  })
+  });
+
+  it('should update sonic\'s colour to red', () => {
+    expect(sonic.setColor('red')).to.be.undefined; // no return value
+    expect(sonic.getColor()).to.equal('red');
+  });
+
+  it('should have sonic say its name', () => {
+    expect(sonic.sayHi()).to.equal('Hi, my name is Sonic');
+  });
 })

--- a/exercises/es-ts-new/exercise.spec.ts
+++ b/exercises/es-ts-new/exercise.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, before } from 'mocha';
+import { Hedgehog, Sonic } from './exercise';
+import { expect } from 'chai';
+
+describe('TypeScript Classes', () => {
+  let sonic: Sonic;
+
+  before(() => {
+    sonic = new Sonic('blue', 10, 100);
+  });
+
+  it('should get 100 rings', () => {
+    expect(sonic.getNumberOfRings()).to.equal(100);
+  });
+
+  it('should get 10 as the weight', () => {
+    expect(sonic.getWeight()).to.equal(10);
+  });
+
+  it('should get blue as the colour', () => {
+    expect(sonic.getColor()).to.equal('blue');
+  })
+})

--- a/exercises/es-ts-new/exercise.ts
+++ b/exercises/es-ts-new/exercise.ts
@@ -50,12 +50,17 @@ export class Sonic extends Hedgehog implements SonicInterface {
   private numberOfRings: number;
   private name: string;
   private itemsOwned: string[];
+  private personalInfo: object;
 
   constructor (color: string, weight: number, numberOfRings: number) {
     super(color, weight);
     this.numberOfRings = numberOfRings;
     this.name = 'Sonic';
     this.itemsOwned = ['speed shoes', 'fire shield']; // items owned by default
+    this.personalInfo = {
+      age: 26,
+      faveConsole: 'Genesis'
+    };
   }
 
   getColor(): string {
@@ -68,6 +73,14 @@ export class Sonic extends Hedgehog implements SonicInterface {
 
   getNumberOfRings(): number {
     return this.numberOfRings;
+  }
+
+  getItems(): string[] {
+    return this.itemsOwned;
+  }
+
+  getPersonalInfo(): object {
+    return this.personalInfo;
   }
 
   setColor(newColor: string): void {
@@ -86,13 +99,30 @@ export class Sonic extends Hedgehog implements SonicInterface {
     /*
      * EXERCISE: swap ...this.itemsOwned with newItem so that when 
      * addItem is called, newItem will be added to the front of the array
-     * whereas unit test will test whether the newItem was added at the end
+     * whereas unit test will test whether the newItem was added at the end.
+     * Also maybe remove assigning to this.itemsOwned. This could be a good 
+     * opportunity to demonstrate that spread is an immutable operation
      */
     this.itemsOwned = [ ...this.itemsOwned, newItem ];
   }
 
-  getItems(): string[] {
-    return this.itemsOwned;
+  addNewPersonalInfo(key: string, value: any) {
+    /*
+     * EXERCISE: note that swapping exercise for array spread wouldn't work because 
+     * JSON key-value pairs are supposed to be orderless. This could be used to demonstrate
+     * immutable nature of object spreading
+     */
+    this.personalInfo = { ...this.personalInfo, [key]: value };
+  }
+
+  /*
+   * EXERCISE: remove one of the destructured variables and create a typo for another one
+   * numberOfRings -> rings, for instance
+   */
+  setColorWeightRings({ color, weight, numberOfRings }) {
+    this.color = color;
+    this.weight = weight;
+    this.numberOfRings = numberOfRings;
   }
 
   sayHi(): string {

--- a/exercises/es-ts-new/exercise.ts
+++ b/exercises/es-ts-new/exercise.ts
@@ -1,0 +1,53 @@
+interface HedgehogInterface {
+  color: string;
+  weight: number;
+  getColor(): string;
+  getWeight(): number;
+}
+
+export class Hedgehog implements HedgehogInterface {
+  color: string;
+  weight: number;
+
+  constructor (color: string, weight: number) {
+    this.color = color;
+    this.weight = weight;
+  }
+
+  getColor() : string {
+    return this.color;
+  }
+
+  getWeight(): number {
+    return this.weight;
+  }
+}
+
+interface SonicInterface {
+  color: string;
+  weight: number;
+  getColor(): string;
+  getWeight(): number;
+  getNumberOfRings(): number;
+}
+
+export class Sonic extends Hedgehog implements SonicInterface {
+  numberOfRings: number;
+
+  constructor (color: string, weight: number, numberOfRings: number) {
+    super(color, weight);
+    this.numberOfRings = numberOfRings;
+  }
+
+  getColor() : string {
+    return this.color;
+  }
+
+  getWeight() : number {
+    return this.weight;
+  }
+
+  getNumberOfRings() : number {
+    return this.numberOfRings;
+  }
+}

--- a/exercises/es-ts-new/exercise.ts
+++ b/exercises/es-ts-new/exercise.ts
@@ -49,11 +49,13 @@ interface SonicInterface {
 export class Sonic extends Hedgehog implements SonicInterface {
   private numberOfRings: number;
   private name: string;
+  private itemsOwned: string[];
 
   constructor (color: string, weight: number, numberOfRings: number) {
     super(color, weight);
     this.numberOfRings = numberOfRings;
     this.name = 'Sonic';
+    this.itemsOwned = ['speed shoes', 'fire shield']; // items owned by default
   }
 
   getColor(): string {
@@ -70,6 +72,27 @@ export class Sonic extends Hedgehog implements SonicInterface {
 
   setColor(newColor: string): void {
     this.color = newColor;
+  }
+
+  /*
+   * EXERCISE: remove setName() definition so that compiler will fails
+   * since Interface expects implementation of setName()
+   */
+  setName(newName: string): void {
+    this.name = newName;
+  }
+
+  addItem(newItem: string): void {
+    /*
+     * EXERCISE: swap ...this.itemsOwned with newItem so that when 
+     * addItem is called, newItem will be added to the front of the array
+     * whereas unit test will test whether the newItem was added at the end
+     */
+    this.itemsOwned = [ ...this.itemsOwned, newItem ];
+  }
+
+  getItems(): string[] {
+    return this.itemsOwned;
   }
 
   sayHi(): string {

--- a/exercises/es-ts-new/exercise.ts
+++ b/exercises/es-ts-new/exercise.ts
@@ -106,7 +106,7 @@ export class Sonic extends Hedgehog implements SonicInterface {
     this.itemsOwned = [ ...this.itemsOwned, newItem ];
   }
 
-  addNewPersonalInfo(key: string, value: any) {
+  addNewPersonalInfo(key: string, value: any): void {
     /*
      * EXERCISE: note that swapping exercise for array spread wouldn't work because 
      * JSON key-value pairs are supposed to be orderless. This could be used to demonstrate
@@ -119,7 +119,7 @@ export class Sonic extends Hedgehog implements SonicInterface {
    * EXERCISE: remove one of the destructured variables and create a typo for another one
    * numberOfRings -> rings, for instance
    */
-  setColorWeightRings({ color, weight, numberOfRings }) {
+  setColorWeightRings({ color, weight, numberOfRings }): void {
     this.color = color;
     this.weight = weight;
     this.numberOfRings = numberOfRings;

--- a/exercises/es-ts-new/exercise.ts
+++ b/exercises/es-ts-new/exercise.ts
@@ -1,53 +1,82 @@
 interface HedgehogInterface {
   color: string;
+  /*
+   * EXERCISE: compilation fails because 'weight' is of wrong type
+   * with `number` replaced with `string`
+   */
   weight: number;
-  getColor(): string;
-  getWeight(): number;
 }
 
 export class Hedgehog implements HedgehogInterface {
-  color: string;
-  weight: number;
+  private _color: string;
+  private _weight: number;
 
   constructor (color: string, weight: number) {
-    this.color = color;
-    this.weight = weight;
+    this._color = color;
+    this._weight = weight;
   }
 
-  getColor() : string {
+  get color(): string {
+    return this._color;
+  }
+
+  get weight(): number {
+    return this._weight;
+  }
+
+  /* 
+   * EXERCISE: compilation fails because `color` is a read-only property
+   * with `set color` removed.
+   */
+  set color(newColor: string) {
+    this._color = newColor;
+  }
+
+  set weight(newWeight: number) {
+    this._weight = newWeight;
+  }
+}
+
+interface SonicInterface {
+  getColor(): string;
+  getWeight(): number;
+  getNumberOfRings(): number;
+  setColor(newColor: string): void;
+  setName(newName: string): void;
+  sayHi(): string;
+}
+
+export class Sonic extends Hedgehog implements SonicInterface {
+  private numberOfRings: number;
+  private name: string;
+
+  constructor (color: string, weight: number, numberOfRings: number) {
+    super(color, weight);
+    this.numberOfRings = numberOfRings;
+    this.name = 'Sonic';
+  }
+
+  getColor(): string {
     return this.color;
   }
 
   getWeight(): number {
     return this.weight;
   }
-}
 
-interface SonicInterface {
-  color: string;
-  weight: number;
-  getColor(): string;
-  getWeight(): number;
-  getNumberOfRings(): number;
-}
-
-export class Sonic extends Hedgehog implements SonicInterface {
-  numberOfRings: number;
-
-  constructor (color: string, weight: number, numberOfRings: number) {
-    super(color, weight);
-    this.numberOfRings = numberOfRings;
-  }
-
-  getColor() : string {
-    return this.color;
-  }
-
-  getWeight() : number {
-    return this.weight;
-  }
-
-  getNumberOfRings() : number {
+  getNumberOfRings(): number {
     return this.numberOfRings;
+  }
+
+  setColor(newColor: string): void {
+    this.color = newColor;
+  }
+
+  sayHi(): string {
+    /*
+     * EXERCISE: replace ${this.name} with something like ${this.color}
+     * so that it doesn't print "Hi, my name is Sonic"
+     */
+    return `Hi, my name is ${this.name}`;
   }
 }

--- a/exercises/es-ts-new/mocha.opts
+++ b/exercises/es-ts-new/mocha.opts
@@ -1,0 +1,4 @@
+--require ts-node/register
+--require chai
+--watch-extensions ts
+*.spec.ts

--- a/exercises/es-ts-new/package.json
+++ b/exercises/es-ts-new/package.json
@@ -4,12 +4,14 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "test": "mocha --opts mocha.opts && rm -rf test",
-    "test:json": "mocha --opts mocha.opts --reporter json && rm -rf test",
-    "start": "ts-node exercise.ts"
+    "test": "mocha --opts mocha.opts && rm -rf test || true",
+    "test:json": "mocha --opts mocha.opts --reporter json && rm -rf test || true",
+    "compile": "tsc exercise.ts && rm -rf exercise.js && echo \"Compilation was successful\" || true",
+    "start": "ts-node exercise.ts || true"
   },
   "dependencies": {
     "chai": "^3.5.0",
+    "es6-promise": "^4.1.0",
     "mocha": "^3.2.0",
     "typescript": "^2.2.1"
   },

--- a/exercises/es-ts-new/package.json
+++ b/exercises/es-ts-new/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "es-ts-new",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "test": "mocha --opts mocha.opts && rm -rf test",
+    "test:json": "mocha --opts mocha.opts --reporter json && rm -rf test",
+    "start": "ts-node exercise.ts"
+  },
+  "dependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0",
+    "typescript": "^2.2.1"
+  },
+  "devDependencies": {
+    "ts-node": "^2.1.0"
+  }
+}


### PR DESCRIPTION
**DO NOT MERGE (at least not for now).**

Connects #181 .

This PR contains a *prototype* TypeScript/ES6 exercises setup that utilizes unit tests. As discussed, we determined that it's not entirely appropriate to create exercises for core programming language features with an opinionated framework like Angular. Hence, this barebones TypeScript + unit tests setup does not involve any Angular code.

Currently the unit tests are *not* set to fail and roughly covers TypeScript/ES6 classes, inheritance and interfaces.

TODO: 
  * ~Prettify or format compiler error in case TypeScript compilation fails. Currently compiler errors are quite ugly with stack trace mixed in and this could be confusing for newcomers to TypeScript. Could be done with `pretty` TypeScript compiler option but I haven't had success with this yet.~
    * Not quite possible: the best I can do is clean up the NPM script's miscellaneous logging with `npm run -s` option.
  * If this prototype setup looks good, will expand the code to cover remaining ES6 and TypeScript concepts

Used the following tools for this setup:
* [`ts-node`](https://github.com/TypeStrong/ts-node): similar to `babel-node` allows seamless compilation and execution of TypeScript code at Node (not for production, only for dev and educational purposes).
* [Mocha](https://mochajs.org/) test runner.
* `ts-node/register` is used to test and run TypeScript code in Mocha.
* [Chai](http://chaijs.com/) assertion library. In particular, using `expect` due to its API similarity (but not exactly the same) with Jasmine, which is used by Angular.

Questions:
* ~Should the exercises cover ES6 Promise? Promise is not exactly part of TypeScript spec and Angular does not quite utilize it as it uses Observables.~
    * Will cover ES6 Promise.