### PR TITLE
Rework testing slides

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.enabled": true
+}


### PR DESCRIPTION
Rework training slides (#363)
Remove extra "pipe" (#355)
Fixes the typo, changes the code related working with templates and shows where `By` is imported from #368