### PR TITLE
Removes return keyword

### DIFF
--- a/slides/src/content/unit-testing.md
+++ b/slides/src/content/unit-testing.md
@@ -99,7 +99,7 @@ describe('CapitalizePipe', () => {
 describe('CapitalizePipe', () => {
 
   let pipe;
-  
+
   beforeEach(() => {
     pipe = new CapitalizePipe();
   });
@@ -482,7 +482,7 @@ export class TodoService {
   public todoList = [];
   constructor(private http: Http) {}
   getTodoList() {
-    return this.http.get('http://localhost:3000/todos')
+    this.http.get('http://localhost:3000/todos')
       .map(response => response.json())
       .map(item => item.map(todo => this.getTodoTaskForDisplay(todo.label, todo.done, todo.id)))
       .subscribe(todos => this.todoList = todos);


### PR DESCRIPTION
Based on the test case in slide 143, it seems we're testing the naive case where `getTodoList()` is actually meant to set some internal state in the service

It would be more correct in this context to remove the `return` keyword as the subscription is what's setting state

I'll also submit a PR to the example app as well to reflect the code change