### PR TITLE
Added note for redux-tools

### DIFF
--- a/slides/src/content/redux.md
+++ b/slides/src/content/redux.md
@@ -260,6 +260,8 @@ import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 export class AppModule { }
 ```
 
+- Note the store dev tools in chrome will only work once you have injected the `Store` into a component's constructor. 
+
 ---
 <!-- .slide: id="redux-clean-up-html" -->
 ## Clean Up the Main Application's HTML


### PR DESCRIPTION
Closes #539 

Added note into the slide to explain that the redux tools will only work if the `Store` has been injected into a component's constructor. 